### PR TITLE
docs: fix sc.exe invocation in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Via an **Elevated** PowerShell account:
 
 ```sh
 Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
-sc config ssh-agent start=auto
+sc.exe config ssh-agent start=auto
 net start ssh-agent
 ```
 


### PR DESCRIPTION
Running `sc config ssh-agent-start=auto` gave me the following error:

```
> sc config ssh-agent start=auto
At line:1 char:1
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Set-Content], ParameterBindingException
    + FullyQualifiedErrorId : PositionalParameterNotFound,Microsoft.PowerShell.Commands.SetContentCommand
```

Changing from `sc` to `sc.exe` solved it.